### PR TITLE
Burn feature in Backoffice

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+
 import { AuthProvider, AuthService } from './auth';
 import { Callback } from './auth/Callback';
 import { PrivateRoute } from './auth/PrivateRoute';
@@ -8,6 +9,7 @@ import { ClaimPage } from './ClaimPage';
 import { ScanPage } from './ScanPage';
 
 type AppProps = { auth: AuthService };
+
 const App: React.FC<AppProps> = ({ auth }) => (
   <AuthProvider value={auth}>
     <Router>

--- a/client/src/ScanPage/index.tsx
+++ b/client/src/ScanPage/index.tsx
@@ -22,7 +22,7 @@ export const ScanPage: React.FC<RouteComponentProps> = ({ match, history }) => {
   useBodyClassName('poap-app');
 
   return (
-    <>
+    <div className="landing">
       <ScanHeader />
       <Route
         exact
@@ -32,7 +32,7 @@ export const ScanPage: React.FC<RouteComponentProps> = ({ match, history }) => {
       <Route path={`${match.path}scan/:account`} component={AddressTokensPage} />
       <Route path={`${match.path}token/:tokenId`} component={TokenDetailPage} />
       <ScanFooter />
-    </>
+    </div>
   );
 };
 
@@ -66,7 +66,7 @@ const ScanFooter: React.FC = React.memo(() => (
           Powered by <b>POAP</b>
         </p>
         <p>An EthDenver 2019 hack</p>
-        <div className='eth-branding'>
+        <div className="eth-branding">
           <img src={BuiltOnEth} alt="Built on Ethereum" />
         </div>
       </div>

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -37,8 +37,8 @@ export type ENSQueryResult = { valid: false } | { valid: true; address: string }
 
 export type AddressQueryResult = { valid: false } | { valid: true; ens: string };
 
-const API_BASE = 'https://api.poap.xyz';
-// process.env.NODE_ENV === 'development' ? 'http://localhost:8080' : 'https://api.poap.xyz';
+const API_BASE =
+  process.env.NODE_ENV === 'development' ? 'http://localhost:8080' : 'https://api.poap.xyz';
 
 async function fetchJson<A>(input: RequestInfo, init?: RequestInit): Promise<A> {
   const res = await fetch(input, init);
@@ -132,9 +132,6 @@ export async function requestProof(
 export function burnToken(tokenId: string): Promise<any> {
   return secureFetchNoResponse(`${API_BASE}/burn/${tokenId}`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
   });
 }
 

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -5,6 +5,7 @@ export interface TokenInfo {
   tokenId: string;
   owner: string;
   event: PoapEvent;
+  ownerText?: string;
 }
 export interface PoapEvent {
   id: number;
@@ -36,8 +37,8 @@ export type ENSQueryResult = { valid: false } | { valid: true; address: string }
 
 export type AddressQueryResult = { valid: false } | { valid: true; ens: string };
 
-const API_BASE =
-  process.env.NODE_ENV === 'development' ? 'http://localhost:8080' : 'https://api.poap.xyz';
+const API_BASE = 'https://api.poap.xyz';
+// process.env.NODE_ENV === 'development' ? 'http://localhost:8080' : 'https://api.poap.xyz';
 
 async function fetchJson<A>(input: RequestInfo, init?: RequestInit): Promise<A> {
   const res = await fetch(input, init);

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -128,6 +128,15 @@ export async function requestProof(
   });
 }
 
+export function burnToken(tokenId: string): Promise<any> {
+  return secureFetchNoResponse(`${API_BASE}/burn/${tokenId}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
 export async function mintEventToManyUsers(eventId: number, addresses: string[]): Promise<any> {
   return secureFetchNoResponse(`${API_BASE}/actions/mintEventToManyUsers`, {
     method: 'POST',

--- a/client/src/backoffice/BurnPage.tsx
+++ b/client/src/backoffice/BurnPage.tsx
@@ -1,5 +1,5 @@
-import React, { FC, useEffect, useState } from 'react';
-import { Switch, Route, RouteComponentProps } from 'react-router-dom';
+import React, { FC, Fragment, useEffect, useState } from 'react';
+import { Switch, Route, RouteComponentProps, Link } from 'react-router-dom';
 import { Formik, Form, Field, FieldProps, ErrorMessage } from 'formik';
 import classNames from 'classnames';
 import delve from 'dlv';
@@ -44,7 +44,11 @@ const BurnForm: FC<RouteComponentProps> = ({ history }) => {
               )}
             />
             <ErrorMessage name="token" component="p" className="bk-error" />
-            <SubmitButton text="Burn" isSubmitting={isSubmitting} canSubmit={isValid && dirty} />
+            <SubmitButton
+              text="Find token"
+              isSubmitting={isSubmitting}
+              canSubmit={isValid && dirty}
+            />
           </Form>
         )}
       </Formik>
@@ -52,8 +56,9 @@ const BurnForm: FC<RouteComponentProps> = ({ history }) => {
   );
 };
 
-const BurnToken: FC = props => {
+const BurnToken: FC<RouteComponentProps> = props => {
   const tokenId = delve(props, 'match.params.tokenId');
+
   const [token, setToken] = useState<null | TokenInfo>(null);
   const [errorTokenInfo, setErrorTokenInfo] = useState<null | Error>(null);
   const [errorBurn, setErrorBurn] = useState<null | Error>(null);
@@ -106,7 +111,14 @@ const BurnToken: FC = props => {
         </div>
       )}
 
-      {errorTokenInfo && <p className="error">Couldn't find token {tokenId}</p>}
+      {errorTokenInfo && (
+        <Fragment>
+          <p className="bk-error">Couldn't find token {tokenId}</p>
+          <Link to={`/admin/burn`}>
+            <button className="btn">Find another token</button>
+          </Link>
+        </Fragment>
+      )}
       {errorBurn && <p className="error">Couldn't burn token {tokenId}</p>}
       {successBurn && <p>Token {tokenId} was successfully burned!</p>}
     </div>

--- a/client/src/backoffice/BurnPage.tsx
+++ b/client/src/backoffice/BurnPage.tsx
@@ -1,10 +1,14 @@
-import React, { FC } from 'react';
-import { Switch, Route } from 'react-router-dom';
-import { Formik, Form, Field } from 'formik';
+import React, { FC, useEffect, useState } from 'react';
+import { Switch, Route, RouteComponentProps } from 'react-router-dom';
+import { Formik, Form, Field, FieldProps, ErrorMessage } from 'formik';
 import * as yup from 'yup';
+import classNames from 'classnames';
+import delve from 'dlv';
 
 /* Helpers */
-import { ADDRESS_REGEXP } from '../lib/constants';
+import { getTokenInfo, TokenInfo, burnToken } from '../api';
+/* Components */
+import { SubmitButton } from '../components/SubmitButton';
 
 const BurnPage: FC = () => {
   return (
@@ -16,29 +20,38 @@ const BurnPage: FC = () => {
 };
 
 const BurnFormSchema = yup.object().shape({
-  token: yup
-    .string()
-    .matches(ADDRESS_REGEXP, 'Must be a valid Ethereum Address')
-    .nullable(),
+  tokenId: yup
+    .number()
+    .required()
+    .positive()
+    .integer(),
 });
 
-const BurnForm: FC = () => {
+const BurnForm: FC<RouteComponentProps> = ({ history }) => {
   return (
-    <div>
-      <h2>My Form</h2>
+    <div className="content-event aos-init aos-animate" data-aos="fade-up" data-aos-delay="300">
+      <p>From here you will be able to search and burn any token you desire</p>
       <Formik
-        initialValues={{ token: '' }}
+        initialValues={{ tokenId: '' }}
         validationSchema={BurnFormSchema}
-        onSubmit={values => {
-          // same shape as initial values
-          console.log(values);
-        }}
+        onSubmit={values => history.push(`/admin/burn/${values.tokenId}`)}
       >
-        {({ errors, touched }) => (
-          <Form>
-            <Field name="token" />
-            {errors.token && touched.token ? <div>{errors.token}</div> : null}
-            <button type="submit">Burn</button>
+        {({ dirty, isValid, isSubmitting }) => (
+          <Form className="login-form">
+            <Field
+              name="tokenId"
+              render={({ field, form }: FieldProps) => (
+                <input
+                  type="text"
+                  autoComplete="off"
+                  placeholder="178223"
+                  className={classNames(!!form.errors[field.name] && 'error')}
+                  {...field}
+                />
+              )}
+            />
+            <ErrorMessage name="token" component="p" className="bk-error" />
+            <SubmitButton text="Burn" isSubmitting={isSubmitting} canSubmit={isValid && dirty} />
           </Form>
         )}
       </Formik>
@@ -46,8 +59,54 @@ const BurnForm: FC = () => {
   );
 };
 
-const BurnToken: FC = () => {
-  return <div>hola soy el token</div>;
+const BurnToken: FC = props => {
+  const tokenId = delve(props, 'match.params.tokenId');
+  const [token, setToken] = useState<null | TokenInfo>(null);
+  const [errorTokenInfo, setErrorTokenInfo] = useState<null | Error>(null);
+  // const [errorBurn, setErrorBurn] = useState<null | Error>(null);
+  /*
+
+  TODO:    - Set error and success for burn
+           - Set loading for Burn Tokens
+  */
+
+  useEffect(() => {
+    getTokenInfo(tokenId)
+      .then(token => setToken(token))
+      .catch(error => setErrorTokenInfo(error));
+  }, [tokenId]);
+
+  const handleBurn = async (tokenId: string) => {
+    await burnToken(tokenId);
+  };
+
+  return (
+    <div className="content-event aos-init aos-animate" data-aos="fade-up" data-aos-delay="300">
+      <h2>Token Info</h2>
+
+      {token && (
+        <div className="card">
+          <div className="content">
+            <div>
+              <img src={token.event.image_url} alt={token.event.description} className="avatar" />
+            </div>
+            <div>
+              <h3>{token.event.name}</h3>
+              <p>{token.event.description}</p>
+            </div>
+          </div>
+
+          <div className="actions">
+            <button className="action-btn" onClick={() => handleBurn(token.tokenId)}>
+              Burn token
+            </button>
+          </div>
+        </div>
+      )}
+
+      {errorTokenInfo && <p className="error">Couldn't find your token</p>}
+    </div>
+  );
 };
 
 export { BurnPage };

--- a/client/src/backoffice/BurnPage.tsx
+++ b/client/src/backoffice/BurnPage.tsx
@@ -9,6 +9,7 @@ import { getTokenInfo, TokenInfo, burnToken } from '../api';
 import { BurnFormSchema } from '../lib/schemas';
 /* Components */
 import { SubmitButton } from '../components/SubmitButton';
+import { Loading } from '../components/Loading';
 
 const BurnPage: FC = () => {
   return (
@@ -55,12 +56,9 @@ const BurnToken: FC = props => {
   const tokenId = delve(props, 'match.params.tokenId');
   const [token, setToken] = useState<null | TokenInfo>(null);
   const [errorTokenInfo, setErrorTokenInfo] = useState<null | Error>(null);
-  // const [errorBurn, setErrorBurn] = useState<null | Error>(null);
-  /*
-
-  TODO:    - Set error and success for burn
-           - Set loading for Burn Tokens
-  */
+  const [errorBurn, setErrorBurn] = useState<null | Error>(null);
+  const [loadingBurn, setLoadingBurn] = useState<null | boolean>(null);
+  const [successBurn, setSuccessBurn] = useState<null | boolean>(null);
 
   useEffect(() => {
     getTokenInfo(tokenId)
@@ -69,7 +67,15 @@ const BurnToken: FC = props => {
   }, [tokenId]);
 
   const handleBurn = async (tokenId: string) => {
-    await burnToken(tokenId);
+    try {
+      setLoadingBurn(true);
+      const res = await burnToken(tokenId);
+      if (res.status === 204) setSuccessBurn(true);
+    } catch (error) {
+      setErrorBurn(error);
+    } finally {
+      setLoadingBurn(false);
+    }
   };
 
   return (
@@ -89,14 +95,20 @@ const BurnToken: FC = props => {
           </div>
 
           <div className="actions">
-            <button className="action-btn" onClick={() => handleBurn(token.tokenId)}>
-              Burn token
-            </button>
+            {loadingBurn ? (
+              <Loading />
+            ) : (
+              <button className="action-btn" onClick={() => handleBurn(token.tokenId)}>
+                Burn token
+              </button>
+            )}
           </div>
         </div>
       )}
 
-      {errorTokenInfo && <p className="error">Couldn't find your token</p>}
+      {errorTokenInfo && <p className="error">Couldn't find token {tokenId}</p>}
+      {errorBurn && <p className="error">Couldn't burn token {tokenId}</p>}
+      {successBurn && <p>Token {tokenId} was successfully burned!</p>}
     </div>
   );
 };

--- a/client/src/backoffice/BurnPage.tsx
+++ b/client/src/backoffice/BurnPage.tsx
@@ -1,12 +1,12 @@
 import React, { FC, useEffect, useState } from 'react';
 import { Switch, Route, RouteComponentProps } from 'react-router-dom';
 import { Formik, Form, Field, FieldProps, ErrorMessage } from 'formik';
-import * as yup from 'yup';
 import classNames from 'classnames';
 import delve from 'dlv';
 
 /* Helpers */
 import { getTokenInfo, TokenInfo, burnToken } from '../api';
+import { BurnFormSchema } from '../lib/schemas';
 /* Components */
 import { SubmitButton } from '../components/SubmitButton';
 
@@ -18,14 +18,6 @@ const BurnPage: FC = () => {
     </Switch>
   );
 };
-
-const BurnFormSchema = yup.object().shape({
-  tokenId: yup
-    .number()
-    .required()
-    .positive()
-    .integer(),
-});
 
 const BurnForm: FC<RouteComponentProps> = ({ history }) => {
   return (

--- a/client/src/backoffice/BurnPage.tsx
+++ b/client/src/backoffice/BurnPage.tsx
@@ -1,0 +1,53 @@
+import React, { FC } from 'react';
+import { Switch, Route } from 'react-router-dom';
+import { Formik, Form, Field } from 'formik';
+import * as yup from 'yup';
+
+/* Helpers */
+import { ADDRESS_REGEXP } from '../lib/constants';
+
+const BurnPage: FC = () => {
+  return (
+    <Switch>
+      <Route exact path="/admin/burn" component={BurnForm} />
+      <Route exact path="/admin/burn/:tokenId" component={BurnToken} />
+    </Switch>
+  );
+};
+
+const BurnFormSchema = yup.object().shape({
+  token: yup
+    .string()
+    .matches(ADDRESS_REGEXP, 'Must be a valid Ethereum Address')
+    .nullable(),
+});
+
+const BurnForm: FC = () => {
+  return (
+    <div>
+      <h2>My Form</h2>
+      <Formik
+        initialValues={{ token: '' }}
+        validationSchema={BurnFormSchema}
+        onSubmit={values => {
+          // same shape as initial values
+          console.log(values);
+        }}
+      >
+        {({ errors, touched }) => (
+          <Form>
+            <Field name="token" />
+            {errors.token && touched.token ? <div>{errors.token}</div> : null}
+            <button type="submit">Burn</button>
+          </Form>
+        )}
+      </Formik>
+    </div>
+  );
+};
+
+const BurnToken: FC = () => {
+  return <div>hola soy el token</div>;
+};
+
+export { BurnPage };

--- a/client/src/backoffice/BurnPage.tsx
+++ b/client/src/backoffice/BurnPage.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import delve from 'dlv';
 
 /* Helpers */
-import { getTokenInfo, TokenInfo, burnToken } from '../api';
+import { getTokenInfo, TokenInfo, burnToken, getENSFromAddress } from '../api';
 import { BurnFormSchema } from '../lib/schemas';
 /* Components */
 import { SubmitButton } from '../components/SubmitButton';
@@ -67,7 +67,18 @@ const BurnToken: FC<RouteComponentProps> = props => {
 
   useEffect(() => {
     getTokenInfo(tokenId)
-      .then(token => setToken(token))
+      .then(async token => {
+        try {
+          const ens = await getENSFromAddress(token.owner);
+          const ownerText = ens.valid ? `${ens.ens} (${token.owner})` : `${token.owner}`;
+          const tokenParsed = { ...token, ens, ownerText };
+          setToken(tokenParsed);
+        } catch (error) {
+          const ownerText = `${token.owner}`;
+          const tokenParsed = { ...token, ownerText };
+          setToken(tokenParsed);
+        }
+      })
       .catch(error => setErrorTokenInfo(error));
   }, [tokenId]);
 
@@ -94,8 +105,9 @@ const BurnToken: FC<RouteComponentProps> = props => {
               <img src={token.event.image_url} alt={token.event.description} className="avatar" />
             </div>
             <div>
-              <h3>{token.event.name}</h3>
-              <p>{token.event.description}</p>
+              <h3 className="title">{token.event.name}</h3>
+              <p className="subtitle">{token.event.description}</p>
+              <p className="info">{token.ownerText}</p>
             </div>
           </div>
 
@@ -104,7 +116,7 @@ const BurnToken: FC<RouteComponentProps> = props => {
               <Loading />
             ) : (
               <button className="action-btn" onClick={() => handleBurn(token.tokenId)}>
-                Burn token
+                Burn Token
               </button>
             )}
           </div>

--- a/client/src/backoffice/EventsPage.tsx
+++ b/client/src/backoffice/EventsPage.tsx
@@ -2,13 +2,12 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { Link, Switch, Route, RouteComponentProps } from 'react-router-dom';
 import classNames from 'classnames';
 import { Formik, Form, Field, ErrorMessage, FieldProps } from 'formik';
-import * as yup from 'yup';
 
 /* Components */
 import { SubmitButton } from '../components/SubmitButton';
 /* Helpers */
 import { useAsync } from '../react-helpers';
-import { ADDRESS_REGEXP } from '../lib/constants';
+import { PoapEventSchema } from '../lib/schemas';
 import { getEvents, PoapEvent, getEvent, updateEvent, createEvent } from '../api';
 
 export const EventsPage: React.FC = () => {
@@ -20,38 +19,6 @@ export const EventsPage: React.FC = () => {
     </Switch>
   );
 };
-
-const PoapEventSchema = yup.object().shape({
-  year: yup
-    .number()
-    .required()
-    .min(1990)
-    .max(new Date().getFullYear() + 1),
-  start_date: yup
-    .string()
-    .matches(/[0-9]{4}-[0-9]{2}-[0-9]{2}/, 'Date must be expressed in YYYY-MM-DD Format'),
-  end_date: yup
-    .string()
-    .matches(/[0-9]{4}-[0-9]{2}-[0-9]{2}/, 'Date must be expressed in YYYY-MM-DD Format'),
-  image_url: yup
-    .string()
-    .label('Image Url')
-    .required()
-    .url(),
-  event_url: yup
-    .string()
-    .label('Website')
-    .url(),
-  signer_ip: yup
-    .string()
-    .label('Signer Url')
-    .url()
-    .nullable(),
-  signer: yup
-    .string()
-    .matches(ADDRESS_REGEXP, 'Must be a valid Ethereum Address')
-    .nullable(),
-});
 
 const CreateEventForm: React.FC = () => {
   return <EventForm create />;

--- a/client/src/backoffice/EventsPage.tsx
+++ b/client/src/backoffice/EventsPage.tsx
@@ -1,11 +1,15 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { getEvents, PoapEvent, getEvent, updateEvent, createEvent } from '../api';
-import { useAsync } from '../react-helpers';
 import { Link, Switch, Route, RouteComponentProps } from 'react-router-dom';
+import classNames from 'classnames';
 import { Formik, Form, Field, ErrorMessage, FieldProps } from 'formik';
 import * as yup from 'yup';
-import classNames from 'classnames';
+
+/* Components */
 import { SubmitButton } from '../components/SubmitButton';
+/* Helpers */
+import { useAsync } from '../react-helpers';
+import { ADDRESS_REGEXP } from '../lib/constants';
+import { getEvents, PoapEvent, getEvent, updateEvent, createEvent } from '../api';
 
 export const EventsPage: React.FC = () => {
   return (
@@ -16,9 +20,6 @@ export const EventsPage: React.FC = () => {
     </Switch>
   );
 };
-
-// const IP_REGEXP = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
-const ADDRESS_REGEXP = /^0x[0-9a-fA-F]{40}$/;
 
 const PoapEventSchema = yup.object().shape({
   year: yup

--- a/client/src/backoffice/IssuePage.tsx
+++ b/client/src/backoffice/IssuePage.tsx
@@ -1,8 +1,11 @@
-import { ErrorMessage, Field, Form, Formik, FormikActions, FieldProps } from 'formik';
 import React from 'react';
-import * as yup from 'yup';
-import { getEvents, mintEventToManyUsers, PoapEvent, mintUserToManyEvents } from '../api';
 import classNames from 'classnames';
+import { ErrorMessage, Field, Form, Formik, FormikActions, FieldProps } from 'formik';
+
+/* Helpers */
+import { getEvents, mintEventToManyUsers, PoapEvent, mintUserToManyEvents } from '../api';
+import { IssueForEventFormValueSchema, IssueForUserFormValueSchema } from '../lib/schemas';
+/* Components */
 import { SubmitButton } from '../components/SubmitButton';
 
 interface IssueForEventPageState {
@@ -14,17 +17,6 @@ interface IssueForEventFormValues {
   eventId: number;
   addressList: string;
 }
-
-const IssueForEventFormValueSchema = yup.object().shape({
-  eventId: yup
-    .number()
-    .required()
-    .min(1),
-  addressList: yup
-    .string()
-    .required()
-    .matches(/^0x[0-9a-fA-F]{40}(\n0x[0-9a-fA-F]{40})*\n*$/, 'Not a valid address or address list'),
-});
 
 export class IssueForEventPage extends React.Component<{}, IssueForEventPageState> {
   state: IssueForEventPageState = {
@@ -143,18 +135,6 @@ interface IssueForUserFormValues {
   eventIds: number[];
   address: string;
 }
-
-const IssueForUserFormValueSchema = yup.object().shape({
-  eventIds: yup
-    .array()
-    .of(yup.number().min(1))
-    .required()
-    .min(1),
-  address: yup
-    .string()
-    .required()
-    .matches(/^0x[0-9a-fA-F]{40}$/, 'Not a valid address'),
-});
 
 export class IssueForUserPage extends React.Component<{}, IssueForUserPageState> {
   state: IssueForUserPageState = {

--- a/client/src/backoffice/Main.tsx
+++ b/client/src/backoffice/Main.tsx
@@ -1,14 +1,15 @@
 /* eslint jsx-a11y/anchor-is-valid: 0 */
 import React, { useCallback, useContext, useState } from 'react';
-import { slide as Menu } from 'react-burger-menu';
 import { Link, Route, withRouter } from 'react-router-dom';
+import { slide as Menu } from 'react-burger-menu';
 
+/* Assets */
+import PoapLogo from '../images/POAP.svg';
 /* Components */
 import { AuthContext } from '../auth';
 import { EventsPage } from './EventsPage';
+import { BurnPage } from './BurnPage';
 import { IssueForEventPage, IssueForUserPage } from './IssuePage';
-/* Assets */
-import PoapLogo from '../images/POAP.svg';
 
 export const MintersPage = () => <div> This is a MintersPage </div>;
 
@@ -31,9 +32,13 @@ const NavigationMenu = withRouter(({ history }) => {
       <Link to="/admin/events" onClick={closeMenu}>
         Manage Events
       </Link>
+      <Link to="/admin/burn" onClick={closeMenu}>
+        Burn Tokens
+      </Link>
       {/* <Link to="/admin/minters" onClick={closeMenu}>
         Manage Minters
       </Link> */}
+
       <a
         className="bm-item"
         href=""
@@ -71,6 +76,7 @@ export const BackOffice: React.FC = () => (
           <Route path="/admin/issue-for-user" component={IssueForUserPage} />
           <Route path="/admin/events" component={EventsPage} />
           <Route path="/admin/minters" component={MintersPage} />
+          <Route path="/admin/burn" component={BurnPage} />
           <Route
             exact
             path="/admin/"

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -1,0 +1,3 @@
+const ADDRESS_REGEXP = /^0x[0-9a-fA-F]{40}$/;
+
+export { ADDRESS_REGEXP };

--- a/client/src/lib/schemas.ts
+++ b/client/src/lib/schemas.ts
@@ -1,6 +1,6 @@
 import * as yup from 'yup';
 
-import { ADDRESS_REGEXP } from '../lib/constants';
+import { ADDRESS_REGEXP } from './constants';
 
 const BurnFormSchema = yup.object().shape({
   tokenId: yup

--- a/client/src/lib/schemas.ts
+++ b/client/src/lib/schemas.ts
@@ -1,0 +1,73 @@
+import * as yup from 'yup';
+
+import { ADDRESS_REGEXP } from '../lib/constants';
+
+const BurnFormSchema = yup.object().shape({
+  tokenId: yup
+    .number()
+    .required()
+    .positive()
+    .integer(),
+});
+
+const PoapEventSchema = yup.object().shape({
+  year: yup
+    .number()
+    .required()
+    .min(1990)
+    .max(new Date().getFullYear() + 1),
+  start_date: yup
+    .string()
+    .matches(/[0-9]{4}-[0-9]{2}-[0-9]{2}/, 'Date must be expressed in YYYY-MM-DD Format'),
+  end_date: yup
+    .string()
+    .matches(/[0-9]{4}-[0-9]{2}-[0-9]{2}/, 'Date must be expressed in YYYY-MM-DD Format'),
+  image_url: yup
+    .string()
+    .label('Image Url')
+    .required()
+    .url(),
+  event_url: yup
+    .string()
+    .label('Website')
+    .url(),
+  signer_ip: yup
+    .string()
+    .label('Signer Url')
+    .url()
+    .nullable(),
+  signer: yup
+    .string()
+    .matches(ADDRESS_REGEXP, 'Must be a valid Ethereum Address')
+    .nullable(),
+});
+
+const IssueForEventFormValueSchema = yup.object().shape({
+  eventId: yup
+    .number()
+    .required()
+    .min(1),
+  addressList: yup
+    .string()
+    .required()
+    .matches(/^0x[0-9a-fA-F]{40}(\n0x[0-9a-fA-F]{40})*\n*$/, 'Not a valid address or address list'),
+});
+
+const IssueForUserFormValueSchema = yup.object().shape({
+  eventIds: yup
+    .array()
+    .of(yup.number().min(1))
+    .required()
+    .min(1),
+  address: yup
+    .string()
+    .required()
+    .matches(/^0x[0-9a-fA-F]{40}$/, 'Not a valid address'),
+});
+
+export {
+  BurnFormSchema,
+  PoapEventSchema,
+  IssueForEventFormValueSchema,
+  IssueForUserFormValueSchema,
+};

--- a/client/src/scss/components/_backoffice.scss
+++ b/client/src/scss/components/_backoffice.scss
@@ -68,6 +68,10 @@
   @include x-rem(font-size, 16px);
 }
 
+.btn {
+  min-height: 51px;
+}
+
 .btn.loading {
   background: url('../images/loading.svg') no-repeat center center #ccc4f7;
   background-size: 30px;
@@ -83,4 +87,44 @@
   color: #3d9423;
   margin: 16px 0;
   font-weight: bold;
+}
+
+.card {
+  width: 100%;
+  border-radius: 3px;
+  background: rgb(255, 255, 255);
+  border: 1px solid rgb(230, 230, 230);
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 16px 18px;
+  text-align: left;
+
+  .content {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+
+    h3 {
+      margin: 0 0 2px 0;
+    }
+  }
+
+  .actions {
+    display: flex;
+  }
+}
+
+.avatar {
+  max-width: 36px;
+  border-radius: 50%;
+  margin-right: 16px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+.action-btn {
+  all: unset;
+  font-size: 18px;
+  cursor: pointer;
+  color: $color-primary;
 }

--- a/client/src/scss/components/_backoffice.scss
+++ b/client/src/scss/components/_backoffice.scss
@@ -60,7 +60,6 @@
 
 .bk-error {
   color: #e13c5d;
-  margin: 0 0 16px;
 
   // margin-top: 5px;
   // @include x-rem(font-size, 14px);

--- a/client/src/scss/components/_backoffice.scss
+++ b/client/src/scss/components/_backoffice.scss
@@ -104,8 +104,19 @@
     flex-direction: row;
     justify-content: space-between;
 
-    h3 {
+    .title {
       margin: 0 0 2px 0;
+    }
+
+    .subtitle {
+      font-size: 16px;
+      margin: 0 0 4px 0;
+    }
+
+    .info {
+      margin: 0;
+      font-size: 12px;
+      color: rgba(0, 0, 0, 0.65);
     }
   }
 
@@ -117,7 +128,7 @@
 .avatar {
   max-width: 36px;
   border-radius: 50%;
-  margin-right: 16px;
+  margin-right: 12px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 

--- a/client/src/scss/globals/_boilerplate.scss
+++ b/client/src/scss/globals/_boilerplate.scss
@@ -17,13 +17,13 @@ body {
 }
 
 header,
-main{
+main {
   float: left;
   width: 100%;
   clear: both;
 }
 
-#root {
+#root .landing {
   min-height: 100vh;
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## What's new?
- Now the admin could burn a token having it's id beforehand.

## Closes issue(s)
- [POAP-20](https://xivis.atlassian.net/secure/RapidBoard.jspa?rapidView=120&projectKey=POAP&modal=detail&selectedIssue=POAP-20)

## Changes include
- [x] Adds `/admin/burn` and `/admin/burn/:tokenId` routes
- [x] Adds `burnToken` method in `api.ts` file
- [x] Fix layout problems since we target #root 
- [x] Display token information and a `Burn token` action
- [x] Move all yup validation schemas to `/lib/schemas` folder


## Self-QA Checklist
- [x] I have tested this code
- [ ] I have updated the README (if needed)
- [x] This branch has been rebased from dev before creating the pull-request
- [ ] **Pull-request build** has passed
